### PR TITLE
NetMD download crypto fixes

### DIFF
--- a/libnetmd/secure.c
+++ b/libnetmd/secure.c
@@ -413,9 +413,13 @@ netmd_error netmd_prepare_packets(unsigned char* data, size_t data_lenght,
 
     gcry_cipher_hd_t key_handle;
     gcry_cipher_hd_t data_handle;
-    unsigned char iv[8] = { 0 };
-    unsigned char rand[8] = { 0 };
-    unsigned char key[8] = { 0 };
+
+    /* We have no use for "security" (= DRM) so just use constant IV.
+     * However, the key has to be randomized, because the device apparently checks
+     * during track commit that the same key is not re-used during a single session. */
+    unsigned char iv[8] = { 0, 0, 0, 0, 0, 0, 0 ,0 };
+    unsigned char raw_key[8] = { 0 }; /* data encryption key */
+    unsigned char key[8] = { 0 }; /* data encryption key wrapped with session key */
 
     netmd_error error = NETMD_NO_ERROR;
 
@@ -426,12 +430,9 @@ netmd_error netmd_prepare_packets(unsigned char* data, size_t data_lenght,
     gcry_cipher_open(&data_handle, GCRY_CIPHER_DES, GCRY_CIPHER_MODE_CBC, 0);
     gcry_cipher_setkey(key_handle, key_encryption_key, 8);
 
-    /* generate initial iv */
-    gcry_create_nonce(iv, sizeof(iv));
-
-    /* generate key, use same key for all packets*/
-    gcry_randomize(rand, sizeof(rand), GCRY_STRONG_RANDOM);
-    gcry_cipher_decrypt(key_handle, key, 8, rand, sizeof(rand));
+    /* generate key, use same key for all packets */
+    gcry_randomize(raw_key, sizeof(raw_key), GCRY_STRONG_RANDOM);
+    gcry_cipher_decrypt(key_handle, key, 8, raw_key, sizeof(raw_key));
 
     *packet_count = 0;
     while (position < data_lenght) {
@@ -442,7 +443,7 @@ netmd_error netmd_prepare_packets(unsigned char* data, size_t data_lenght,
         else
            chunksize = first_chunk - 24U;
 
-       packet_data_length = chunksize;
+        packet_data_length = chunksize;
 
         if ((data_lenght - position) < chunksize) {                  // last packet
             packet_data_length = data_lenght - position;             // do not encrypt padding bytes

--- a/libnetmd/secure.c
+++ b/libnetmd/secure.c
@@ -409,7 +409,7 @@ netmd_error netmd_prepare_packets(unsigned char* data, size_t data_lenght,
      * Large sizes cause instability in some players especially with ATRAC3 files. */
     size_t chunksize, packet_data_length, first_chunk = 0x00100000U;
     size_t frame_size = netmd_get_frame_size(format);
-    int padding = 0;
+    int padding = 0, frame_padding = 0;
     netmd_track_packets *last = NULL;
     netmd_track_packets *next = NULL;
 
@@ -443,7 +443,7 @@ netmd_error netmd_prepare_packets(unsigned char* data, size_t data_lenght,
         if ((*packet_count) > 0)
             chunksize = first_chunk;
         else
-           chunksize = first_chunk - 24U;
+            chunksize = first_chunk - 24U;
 
         packet_data_length = chunksize;
 
@@ -456,11 +456,12 @@ netmd_error netmd_prepare_packets(unsigned char* data, size_t data_lenght,
             }
             /* do not truncate if last frame is incomplete, include padding bytes for DES encryption in size calculation */
             if((data_lenght % frame_size) != 0 || padding != 0) {
-                padding = frame_size - (data_lenght % frame_size) - padding;
-                if(padding < 0)
-                    padding += frame_size;
+                frame_padding = frame_size - (data_lenght % frame_size) - padding;
+                if(frame_padding < 0)
+                    frame_padding += frame_size;
             }
-            chunksize = packet_data_length + padding;
+            chunksize = packet_data_length + frame_padding;
+            netmd_log(NETMD_LOG_VERBOSE, "last packet: packet_data_length=%d, padding=%d, frame_padding=%d, chunksize=%d\n", packet_data_length, padding, frame_padding, chunksize);
         }
 
         /* alloc memory */

--- a/libnetmd/secure.c
+++ b/libnetmd/secure.c
@@ -405,7 +405,9 @@ netmd_error netmd_prepare_packets(unsigned char* data, size_t data_lenght,
                                   unsigned char *key_encryption_key, netmd_wireformat format)
 {
     size_t position = 0;
-    size_t chunksize, packet_data_length, first_chunk = 0x00800000U;     // limit chunksize to multiple of 16384 bytes (incl. 24 byte header data for first packet)
+    /* Limit chunksize to multiple of 16384 bytes (incl. 24 byte header data for first packet).
+     * Large sizes cause instability in some players especially with ATRAC3 files. */
+    size_t chunksize, packet_data_length, first_chunk = 0x00100000U;
     size_t frame_size = netmd_get_frame_size(format);
     int padding = 0;
     netmd_track_packets *last = NULL;

--- a/libnetmd/secure.c
+++ b/libnetmd/secure.c
@@ -484,8 +484,9 @@ netmd_error netmd_prepare_packets(unsigned char* data, size_t data_lenght,
         gcry_cipher_setiv(data_handle, iv, 8);
         gcry_cipher_setkey(data_handle, rand, sizeof(rand));
         gcry_cipher_encrypt(data_handle, next->data, chunksize, data + position, packet_data_length);
-        /* set last encrypted block as iv for the next packet */
-        memcpy(iv, data + position + packet_data_length - 8, 8);
+        /* use last encrypted block as iv for the next packet so we keep
+         * on Cipher Block Chaining */
+        memcpy(iv, next->data + chunksize - 8, 8);
 
         /* next packet */
         position = position + chunksize;


### PR DESCRIPTION
This PR has fixes for a few crypto issues in your NetMD download support branch:

  1. Inter-packet IV setting fixed to use ciphertext instead of plaintext: fixes noise at packet boundaries.
  2. Simplified padding calculation: since all frame sizes are divisible by 8, separate cipher padding calculation is unnecessary.
  3. Last packet encryption fixed to always use `outlen` = `inlen` when calling `gcry_cipher_encrypt`: fixes noise at end of track.

I also reduced chunksize to 1MB since that seemed to lessen USB interface crashes on my device and this had eseentially no effect on speed. This is tested with both PCM and LP2 on an MZ-N710.